### PR TITLE
Bump the ab-test-confidence to fix Chrome carping about undeclared var

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "next-js-setup": "~2.5.1",
     "keen-js": "~3.2.4",
     "querystring": "~3.46.1",
-    "ab-test-confidence": "~1.1.0"
+    "ab-test-confidence": "~1.2.0"
   },
   "resolutions": {
     "isomorphic-fetch": "^2.0.2",


### PR DESCRIPTION
/cc @adambraimbridge 

ref: https://github.com/Financial-Times/ab-test-confidence/pull/4