### PR TITLE
Update AB test keen query

### DIFF
--- a/client/queries/ab/engaged-follow.js
+++ b/client/queries/ab/engaged-follow.js
@@ -9,7 +9,7 @@ var visualise   = require('./visualise');
 module.exports.on = new Keen.Query("funnel", { steps: [
 		{
 			event_collection: 'dwell',
-			timeframe: { "start" : "2015-06-22T00:00:00.000Z", "end": new Date().toISOString() },
+			timeframe: { "start" : "2015-06-24T15:00:00.000Z", "end": new Date().toISOString() },
 			actor_property: 'user.uuid',
 			filters: [
 				{"property_name":"page.location.type","operator":"eq","property_value":"stream"},
@@ -19,7 +19,7 @@ module.exports.on = new Keen.Query("funnel", { steps: [
 		},
 		{
 			event_collection: 'cta',
-			timeframe: { "start" : "2015-06-22T00:00:00.000Z", "end": new Date().toISOString() },
+			timeframe: { "start" : "2015-06-24T15:00:00.000Z", "end": new Date().toISOString() },
 			actor_property: 'user.uuid',
 			filters: [
 				{"property_name":"meta.domPath","operator":"eq","property_value":"myft-engaged-cta | follow"},
@@ -30,17 +30,18 @@ module.exports.on = new Keen.Query("funnel", { steps: [
 module.exports.off = new Keen.Query("funnel", { steps: [
 		{
 			event_collection: 'dwell',
-			timeframe: { "start" : "2015-06-22T00:00:00.000Z", "end": new Date().toISOString() },
+			timeframe: { "start" : "2015-06-24T15:00:00.000Z", "end": new Date().toISOString() },
 			actor_property: 'user.uuid',
 			filters: [
 				{"property_name":"page.location.type","operator":"eq","property_value":"stream"},
 				{"property_name":"user.isStaff","operator":"eq","property_value":false},
+				{"property_name":"user.myft.isEngagedTopic","operator":"eq","property_value":true},
 				{"property_name":"user.ab.myftEngagedFollow","operator":"eq","property_value":"off"}
 			]
 		},
 		{
 			event_collection: 'cta',
-			timeframe: { "start" : "2015-06-22T00:00:00.000Z", "end": new Date().toISOString() },
+			timeframe: { "start" : "2015-06-24T15:00:00.000Z", "end": new Date().toISOString() },
 			actor_property: 'user.uuid',
 			filters: [
 				{"property_name":"meta.domPath","operator":"in","property_value":["sub-header | follow","follow"]},


### PR DESCRIPTION
This ensures that the `control` group within the `engaged-follow` a/b test is filtered by engaged user requests to the stream page, just as the test variant is. This is achieved by using the new `user.myft.isEngagedTopic` beacon event property.