### PR TITLE
Kill tildes, use carets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,13 +2,13 @@
   "name": "next-beacon-dashboard",
   "dependencies": {
     "isomorphic-fetch": "^2.0.0",
-    "sprintf": "~1.0.2",
+    "sprintf": "^1.0.2",
     "o-techdocs": "^4.0.4",
-    "next-js-setup": "~2.5.1",
-    "keen-js": "~3.2.4",
-    "querystring": "~3.46.1",
-    "ab-test-confidence": "~1.2.0",
-    "o-hierarchical-nav": "~2.0.4",
+    "next-js-setup": "^2.5.1",
+    "keen-js": "^3.2.4",
+    "querystring": "^3.46.1",
+    "ab-test-confidence": "^1.2.0",
+    "o-hierarchical-nav": "^2.0.4",
     "array-find": "^1.0.1"
   },
   "resolutions": {


### PR DESCRIPTION
For your peace of mind™, current versions of deps are:
next-js-setup: 2.8.1 (minor version changes, checked and ok)
sprintf: at 1.0.3 (patch version change)
keen-js: at 3.2.6 (patch version change)
querystring: 3.46.1 (up-to-date)
ab-test-confidence: 1.2.0 (up-to-date)
o-hierarchical-nav currently at 2.0.4 (up-to-date)

So all good.