### PR TITLE
update article reports for related stories using n-card

### DIFF
--- a/client/queries/article/actions-by-component.js
+++ b/client/queries/article/actions-by-component.js
@@ -59,8 +59,12 @@ var charts = [
 				{"operator":"in",
 				"property_name":"meta.domPath",
 				"property_value":[
-					"article | more-on-inline | articles | title",
-					"story-package | articles | title"
+					"article | more-on-inline | articles | title", // can remove after Nov 7 2015
+					"story-package | articles | title", // can remove after Nov 7 2015
+					"article | more-on-inline | articles | article-card | headline",
+					"article | more-on-inline | articles | image",
+					"story-package | articles | article-card | headline",
+					"story-package | articles | image"
 					]
 				}
 			]

--- a/client/queries/article/actions-by-type.js
+++ b/client/queries/article/actions-by-type.js
@@ -48,8 +48,12 @@ var charts = [
 				"property_value":[
 					"article | link",
 					"article | promobox | link",
-					"article |  more-on-in-line | articles | title",
-					"story-package | articles | title",
+					"article | more-on-inline | articles | title", // can remove after Nov 7 2015
+					"story-package | articles | title", // can remove after Nov 7 2015
+					"article | more-on-inline | articles | article-card | headline",
+					"article | more-on-inline | articles | image",
+					"story-package | articles | article-card | headline",
+					"story-package | articles | image",
 					"more-on | article-card | headline",
 					"myft-tray | myft-feed | article-card | headline"
 				]}


### PR DESCRIPTION
Related stories in article now make use of n-card, so have updated references in report filters for this. Have left old filter in place with comment for when they can be deleted (90 days from change)