### PR TITLE
Build service v2

### DIFF
--- a/views/layouts/beacon.html
+++ b/views/layouts/beacon.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="{{#hashedAsset}}main.css{{/hashedAsset}}"/>
 		<title>Beacon - next.ft.com performance dashboard</title>
 		<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.6/styles/default.min.css">
-		<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-ft-icons@^2.3.6,o-table@^1.7.2,o-grid@^3.1.6,o-aside-panel@^1.3.2,o-typography@^1.16.4" />
+		<link rel="stylesheet" href="//build.origami.ft.com/v2/bundles/css?modules=o-ft-icons@^2.3.6,o-table@^1.7.2,o-grid@^3.1.6,o-aside-panel@^1.3.2,o-typography@^1.16.4" />
 		<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.9.3/lodash.min.js"></script>
 		{{>next-js-setup/templates/ctm}}
 	</head>
@@ -79,7 +79,7 @@
 		</script>
 		<script src="//code.jquery.com/jquery-2.1.4.min.js" type="text/javascript"></script>
 		<script src="//cdn.jsdelivr.net/keen.js/3.2.4/keen.min.js" type="text/javascript"></script>
-		<script src="//build.origami.ft.com/bundles/js?modules=o-techdocs@^4.0.4"></script>
+		<script src="//build.origami.ft.com/v2/bundles/js?modules=o-techdocs@^4.0.4"></script>
 		{{>next-js-setup/templates/script-loader}}
 	</body>
 </html>


### PR DESCRIPTION
"Hi Nextians, I've been recording Origami Build Service versions for our sites. https://beacon.ft.com should update to V2 of the build service for faster build times with `libsass`. This can be done by appending v2 to the stylesheet URL."
