### PR TITLE
click rates by occurence of component

### DIFF
--- a/client/queries/article/actions-by-component.js
+++ b/client/queries/article/actions-by-component.js
@@ -12,6 +12,7 @@ var client = new Keen({
 });
 
 var keenQuery =	function(options) {
+
 	var parameters = {
 		eventCollection: "cta",
 		filters: [
@@ -40,32 +41,32 @@ var charts = [
 	{queryName: "articleHeaderQuery",
 		elId: ["article-header-trend-linechart", "article-header-trend-areachart"],
 		options: {
-			filters: filters.articleHeaderFilters
+			filters: filters.articleHeaderActionFilters
 	}},
 	{queryName: "moreOnQuery",
 		elId: ["more-on-trend-linechart", "more-on-trend-areachart"],
 		options: {
-			filters: filters.moreOnFilters
+			filters: filters.moreOnActionFilters
 	}},
 	{queryName: "relatedSoriesQuery",
 		elId: ["related-stories-trend-linechart", "related-stories-trend-areachart"],
 		options: {
-			filters: filters.relatedStoriesFilters
+			filters: filters.relatedStoriesActionFilters
 	}},
 	{queryName: "promoboxQuery",
 		elId: ["promo-box-trend-linechart", "promo-box-trend-areachart"],
 		options: {
-			filters: filters.promoboxFilters
+			filters: filters.promoboxActionFilters
 	}},
 	{queryName: "linksQuery",
 		elId: ["links-trend-linechart"],
 		options: {
-			filters: filters.linksFilters
+			filters: filters.linksActionFilters
 	}},
 	{queryName: "tocQuery",
 		elId: ["toc-trend-linechart"],
 		options: {
-			filters: filters.tocFilters
+			filters: filters.tocActionFilters
 	}}
 ];
 

--- a/client/queries/article/engagement-filters.js
+++ b/client/queries/article/engagement-filters.js
@@ -1,12 +1,13 @@
 "use strict";
 
 module.exports = {
-	articleHeaderFilters: [
+	allArticlesBaseFilters: [],
+	articleHeaderActionFilters: [
 		{"operator":"contains",
 		"property_name":"meta.domPath",
 		"property_value":"article | header | "}
 	],
-	moreOnFilters: [
+	moreOnActionFilters: [
 		{"operator":"in",
 		"property_name":"meta.domPath",
 		"property_value": [
@@ -25,7 +26,7 @@ module.exports = {
 			]
 		}
 	],
-	relatedStoriesFilters: [
+	relatedStoriesActionFilters: [
 		{"operator":"in",
 		"property_name":"meta.domPath",
 		"property_value":[
@@ -44,20 +45,40 @@ module.exports = {
 			]
 		}
 	],
-	promoboxFilters: [
+	relatedStoriesBaseFilters: [
+		{"operator":"eq",
+		"property_name":"content_v1.flags.hasStoryPackage",
+		"property_value":true}
+	],
+	promoboxActionFilters: [
 		{"operator":"contains",
 		"property_name":"meta.domPath",
 		"property_value":"article | promobox | "}
 	],
-	linksFilters: [
+	promoboxBaseFilters: [
+		{"operator":"eq",
+		"property_name":"content_v1.flags.hasPromoBox",
+		"property_value":true}
+	],
+	linksActionFilters: [
 		{"operator":"eq",
 		"property_name":"meta.domPath",
 		"property_value":"article | link"}
 	],
-	tocFilters: [
+	linksBaseFilters: [
+		{"operator":"eq",
+		"property_name":"content_v1.flags.hasLinksInBody",
+		"property_value":true}
+	],
+	tocActionFilters: [
 		{"operator":"eq",
 		"property_name":"meta.domPath",
 		"property_value":"article | table-of-contents | toc"}
+	],
+	tocBaseFilters: [
+		{"operator":"eq",
+		"property_name":"content_v1.flags.hasTableOfContents",
+		"property_value":true}
 	],
 	articleLinksFilters: [
 		{"operator":"in",


### PR DESCRIPTION
Use the new spoor feed capabilities to do click rates on article components by occurrence of that component.

eg. Click rate on promo-box is now calculated as clicks as % article pages loaded that have a promo-box