### PR TITLE
reorder article type and component pages to prioritise click rate

### DIFF
--- a/client/queries/article/actions-by-component.js
+++ b/client/queries/article/actions-by-component.js
@@ -39,43 +39,34 @@ var keenQuery =	function(options) {
 
 var charts = [
 	{queryName: "articleHeaderQuery",
-		elId: ["article-header-trend-linechart", "article-header-trend-areachart"],
+		elId: "article-header-trend-areachart",
 		options: {
 			filters: filters.articleHeaderActionFilters
 	}},
 	{queryName: "moreOnQuery",
-		elId: ["more-on-trend-linechart", "more-on-trend-areachart"],
+		elId: "more-on-trend-areachart",
 		options: {
 			filters: filters.moreOnActionFilters
 	}},
 	{queryName: "relatedSoriesQuery",
-		elId: ["related-stories-trend-linechart", "related-stories-trend-areachart"],
+		elId: "related-stories-trend-areachart",
 		options: {
 			filters: filters.relatedStoriesActionFilters
 	}},
 	{queryName: "promoboxQuery",
-		elId: ["promo-box-trend-linechart", "promo-box-trend-areachart"],
+		elId: "promo-box-trend-areachart",
 		options: {
 			filters: filters.promoboxActionFilters
-	}},
-	{queryName: "linksQuery",
-		elId: ["links-trend-linechart"],
-		options: {
-			filters: filters.linksActionFilters
-	}},
-	{queryName: "tocQuery",
-		elId: ["toc-trend-linechart"],
-		options: {
-			filters: filters.tocActionFilters
 	}}
 ];
 
 charts.forEach(function(chart) {
-	client.draw(keenQuery(chart.options), document.getElementById(chart.elId[0]), {
-		chartType: "linechart",
-		title: 'Approximate trend over time',
+	client.draw(keenQuery(chart.options), document.getElementById(chart.elId), {
+		chartType: "areachart",
+		title: 'Approximate trend over time - percentage share',
 		chartOptions: {
 			height: 450,
+			isStacked: 'percent',
 			curveType:'function',
 			hAxis: {
 				format: 'E d'
@@ -86,25 +77,4 @@ charts.forEach(function(chart) {
 			}
 		}
 	});
-});
-
-charts.forEach(function(chart) {
-	if(chart.elId.length > 1) {
-		client.draw(keenQuery(chart.options), document.getElementById(chart.elId[1]), {
-			chartType: "areachart",
-			title: 'Approximate trend over time - percentage share',
-			chartOptions: {
-				height: 450,
-				isStacked: 'percent',
-				curveType:'function',
-				hAxis: {
-					format: 'E d'
-				},
-				chartArea: {
-					left: '10%',
-					width: '75%'
-				}
-			}
-		});
-	}
 });

--- a/client/queries/article/actions-by-type.js
+++ b/client/queries/article/actions-by-type.js
@@ -38,73 +38,25 @@ var keenQuery =	function(options) {
 
 var charts = [
 	{queryName: "articleLinksQuery",
-		elId: [
-			"article-links-trend-linechart",
-			"article-links-trend-areachart",
-			"article-links-trend-percent-areachart"
-		],
+		elId: "article-links-trend-percent-areachart",
 		options: {
 			filters: filters.articleLinksFilters
 	}},
 	{queryName: "topiclinksQuery",
-		elId: [
-			"topic-links-trend-linechart",
-			"topic-links-trend-areachart",
-			"topic-links-trend-percent-areachart"
-		],
+		elId: "topic-links-trend-percent-areachart",
 		options: {
 			filters: filters.topicLinksFilters
 	}},
 	{queryName: "shareQuery",
-		elId: [
-			"share-trend-linechart",
-			"share-trend-areachart",
-			"share-trend-percent-areachart"
-		],
+		elId: "share-trend-percent-areachart",
 		options: {
 			filters: filters.shareLinksFilters
 	}}
 ];
 
-charts.forEach(function(chart) {
-	client.draw(keenQuery(chart.options), document.getElementById(chart.elId[0]), {
-		chartType: "linechart",
-		title: 'Approximate trend over time',
-		chartOptions: {
-			height: 450,
-			curveType:'function',
-			hAxis: {
-				format: 'E d'
-			},
-			chartArea: {
-				left: '10%',
-				width: '75%'
-			}
-		}
-	});
-});
 
 charts.forEach(function(chart) {
-	client.draw(keenQuery(chart.options), document.getElementById(chart.elId[1]), {
-		chartType: "areachart",
-		title: 'Approximate trend over time - stacked',
-		isStacked: true,
-		chartOptions: {
-			height: 450,
-			curveType:'function',
-			hAxis: {
-				format: 'E d'
-			},
-			chartArea: {
-				left: '10%',
-				width: '75%'
-			}
-		}
-	});
-});
-
-charts.forEach(function(chart) {
-	client.draw(keenQuery(chart.options), document.getElementById(chart.elId[2]), {
+	client.draw(keenQuery(chart.options), document.getElementById(chart.elId), {
 		chartType: "areachart",
 		title: 'Approximate trend over time - percentage share',
 		chartOptions: {

--- a/views/article-actions-by-component.html
+++ b/views/article-actions-by-component.html
@@ -14,30 +14,36 @@
 	<a href="?timeframe=previous_90_days">90 days</a>
 </p>
 
-<h2>Article Header</h2>
-<span class="chart__container" id="article-header-trend-linechart"></span>
-<span class="chart__container" id="article-header-trend-areachart"></span>
+<h2>Click Rate by Component<h2>
+
+<h3>Article Header</h3>
 <span class="chart__container" id="article-header-trend-clickrate"></span>
 
-<h2>Related Stories</h2>
-<span class="chart__container" id="related-stories-trend-linechart"></span>
-<span class="chart__container" id="related-stories-trend-areachart"></span>
-<span class="chart__container" id="related-stories-trend-clickrate"></span>
-
-<h2>More On</h2>
-<span class="chart__container" id="more-on-trend-linechart"></span>
-<span class="chart__container" id="more-on-trend-areachart"></span>
-<span class="chart__container" id="more-on-trend-clickrate"></span>
-
-<h2>Article Body Links</h2>
-<span class="chart__container" id="links-trend-linechart"></span>
+<h3>Article Body Links</h3>
 <span class="chart__container" id="links-trend-clickrate"></span>
 
-<h2>Promobox</h2>
-<span class="chart__container" id="promo-box-trend-linechart"></span>
-<span class="chart__container" id="promo-box-trend-areachart"></span>
+<h3>Promobox</h3>
 <span class="chart__container" id="promo-box-trend-clickrate"></span>
 
-<h2>Table of Contents</h2>
-<span class="chart__container" id="toc-trend-linechart"></span>
+<h3>Related Stories</h3>
+<span class="chart__container" id="related-stories-trend-clickrate"></span>
+
+<h3>More On</h3>
+<span class="chart__container" id="more-on-trend-clickrate"></span>
+
+<h3>Table of Contents</h3>
 <span class="chart__container" id="toc-trend-clickrate"></span>
+
+<h2>Click mix within Component<h2>
+
+<h3>Article Header</h3>
+<span class="chart__container" id="article-header-trend-areachart"></span>
+
+<h3>Promobox</h3>
+<span class="chart__container" id="promo-box-trend-areachart"></span>
+
+<h3>Related Stories</h3>
+<span class="chart__container" id="related-stories-trend-areachart"></span>
+
+<h3>More On</h3>
+<span class="chart__container" id="more-on-trend-areachart"></span>

--- a/views/article-actions-by-type.html
+++ b/views/article-actions-by-type.html
@@ -14,23 +14,29 @@
 	<a href="?timeframe=previous_90_days">90 days</a>
 </p>
 
-<h2>Link to another article</h2>
+
+<h2>Click Rate</h2>
+<h3>Link to another article</h3>
 <p><small>note: article links are not differentiated by their destination
 (article or stream) and for this analysis have all been included in links
 to another article)</small></p>
-<span class="chart__container" id="article-links-trend-linechart"></span>
-<span class="chart__container" id="article-links-trend-areachart"></span>
-<span class="chart__container" id="article-links-trend-percent-areachart"></span>
 <span class="chart__container" id="article-links-trend-aggregate"></span>
 
 <h2>Links to a highlighted topic</h2>
-<span class="chart__container" id="topic-links-trend-linechart"></span>
-<span class="chart__container" id="topic-links-trend-areachart"></span>
-<span class="chart__container" id="topic-links-trend-percent-areachart"></span>
 <span class="chart__container" id="topic-links-trend-aggregate"></span>
 
 <h2>Sharing the article</h2>
-<span class="chart__container" id="share-trend-linechart"></span>
-<span class="chart__container" id="share-trend-areachart"></span>
-<span class="chart__container" id="share-trend-percent-areachart"></span>
 <span class="chart__container" id="share-trend-aggregate"></span>
+
+<h2>Click Mix</h2>
+<h3>Link to another article</h3>
+<p><small>note: article links are not differentiated by their destination
+(article or stream) and for this analysis have all been included in links
+to another article)</small></p>
+<span class="chart__container" id="article-links-trend-percent-areachart"></span>
+
+<h3>Links to a highlighted topic</h3>
+<span class="chart__container" id="topic-links-trend-percent-areachart"></span>
+
+<h3>Sharing the article</h3>
+<span class="chart__container" id="share-trend-percent-areachart"></span>


### PR DESCRIPTION
Get rid of absolute numbers and put all click rates together on both type and component pages.