### PR TITLE
Front Page Performance: Page loaded domLoading offset

### DIFF
--- a/client/queries/front-page/performance.js
+++ b/client/queries/front-page/performance.js
@@ -36,6 +36,12 @@ const render = () => {
 			title: 'Fonts loaded',
 			filters: filters.concat([createFilter('exists', 'ingest.context.timings.marks.fontsLoaded', true)]),
 			targetProperty: 'ingest.context.timings.marks.fontsLoaded'
+		},
+		{
+			el: document.querySelector('#page-loaded'),
+			title: 'Page loaded (offset from domLoading, i.e. doesn\'t include connection latency)',
+			filters: filters.concat([createFilter('exists', 'ingest.context.timings.domLoadingOffset.loadEventEnd', true)]),
+			targetProperty: 'ingest.context.timings.domLoadingOffset.loadEventEnd'
 		}
 	]
 		.map(graph => {

--- a/client/queries/performance.js
+++ b/client/queries/performance.js
@@ -167,7 +167,7 @@ const render = () => {
 			},
 			hAxis: {
 				format: 'EEE, d	MMM'
-			},
+			}
 		})
 		.prepare();
 

--- a/views/front-page-performance.html
+++ b/views/front-page-performance.html
@@ -21,3 +21,4 @@
 
 <div id="first-paint-chart"></div>
 <div id="fonts-loaded-chart"></div>
+<div id="page-loaded"></div>


### PR DESCRIPTION
Graph of page loaded timing, as an offset from `domLoading`, i.e. doesn't include connection latenct

(data's only just started collecting)

![screen shot 2016-01-04 at 15 19 02](https://cloud.githubusercontent.com/assets/74132/12092720/b90bb464-b2f6-11e5-90db-36187d729b19.jpeg)
