### PR TITLE
Myft users email openers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,8 @@
     "next-js-setup": "^4.0.0",
     "keen-js": "^3.2.4",
     "ab-test-confidence": "^1.2.0",
-    "moment": "^2.10.6"
+    "moment": "^2.10.6",
+    "n-keen-query": "*"
   },
   "resolutions": {
     "o-errors": "^3.1.0",

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "keen-js": "^3.2.4",
     "ab-test-confidence": "^1.2.0",
     "moment": "^2.10.6",
-    "n-keen-query": "*"
+    "n-keen-query": "^1.0.2"
   },
   "resolutions": {
     "o-errors": "^3.1.0",

--- a/client/queries/myft/usage.js
+++ b/client/queries/myft/usage.js
@@ -67,6 +67,8 @@ function usageForPeriod(startDate, endDate, name) {
 				curr: union(myFtPageVisitors.curr.result, myFtDailyEmailOpeners.curr.result).length,
 				prev: union(myFtPageVisitors.prev.result, myFtDailyEmailOpeners.prev.result).length
 			};
+			nextUserCount.curr = nextUserCount.curr.result;
+			nextUserCount.prev = nextUserCount.prev.result;
 
 			const combined = [
 				['Visited Next', nextUserCount.curr, nextUserCount.prev],
@@ -77,10 +79,10 @@ function usageForPeriod(startDate, endDate, name) {
 				.parseRawData({result: combined})
 				.render();
 
-			var usage = myFtUserCount.curr / nextUserCount.curr.result;
+			var usage = myFtUserCount.curr / nextUserCount.curr;
 			section.querySelector('.numbers-table--usage .numbers-table__current').textContent = (Math.round(usage * 10000 ) / 100) + '%';
 
-			var prevUsage = myFtUserCount.prev / nextUserCount.prev.result;
+			var prevUsage = myFtUserCount.prev / nextUserCount.prev;
 			section.querySelector('.numbers-table--usage .numbers-table__previous').textContent = (Math.round(prevUsage * 10000 ) / 100) + '%';
 
 			var usageDiff = ((usage - prevUsage) / prevUsage);

--- a/client/queries/myft/usage.js
+++ b/client/queries/myft/usage.js
@@ -104,7 +104,7 @@ function usageOverTime(client) {
 		}]
 	});
 
-	var myftArticleViews = new Keen.Query('count', { // second query
+	var myFtArticleViews = new Keen.Query('count', { // second query
 		eventCollection: "dwell",
 		interval: interval,
 		timeframe: timeframe,
@@ -155,7 +155,7 @@ function usageOverTime(client) {
 		}]
 	});
 
-	var myFTUsers = new Keen.Query('count_unique', {
+	var myFtUsers = new Keen.Query('count_unique', {
 		eventCollection: "dwell",
 		interval: interval,
 		timeframe: timeframe,
@@ -174,7 +174,7 @@ function usageOverTime(client) {
 	});
 
 
-	var myFTChart = new Keen.Dataviz()
+	var myFtChart = new Keen.Dataviz()
 		.el(document.getElementById("myft-usage"))
 		.chartType("linechart")
 		.chartOptions({
@@ -206,46 +206,46 @@ function usageOverTime(client) {
 		.prepare();
 
 
-	client.run([nextUsers, followUsers, myFTUsers, articleViews, myftArticleViews], function(err, res) { // run the queries
+	client.run([nextUsers, followUsers, myFtUsers, articleViews, myFtArticleViews], function(err, res) { // run the queries
 
 		var next = res[0].result;
 		var follow = res[1].result;
-		var myft = res[2].result;
+		var myFt = res[2].result;
 		var articles = res[3].result;
-		var myftArticles = res[4].result;
+		var myFtArticles = res[4].result;
 
-		var myFTUsageData = [];
+		var myFtUsageData = [];
 		var articleViewData = [];
 		var articleConsumptionData = [];
 
 		var i=0;
 
 		while (i < follow.length) {
-			myFTUsageData[i]={ // format the data so it can be charted
+			myFtUsageData[i]={ // format the data so it can be charted
 					timeframe: follow[i]["timeframe"],
 					value: [
 							{ category: "Next Users", result: next[i]["value"] },
 							{ category: "Follow users", result: follow[i]["value"] },
-							{ category: "myFT users", result: myft[i]["value"] }
+							{ category: "myFT users", result: myFt[i]["value"] }
 					]
 			};
 			articleViewData[i]={ // format the data so it can be charted
 						timeframe: follow[i]["timeframe"],
 						value: [
 								{ category: "Article Views", result: articles[i]["value"] },
-								{ category: "myFT article views", result: myftArticles[i]["value"] }
+								{ category: "myFT article views", result: myFtArticles[i]["value"] }
 						]
 				};
 			articleConsumptionData[i]={ // format the data so it can be charted
 					timeframe: follow[i]["timeframe"],
 					value: [
-							{ category: "myFT Articles consumed per user", result: myftArticles[i]["value"] / myft[i]["value"] }
+							{ category: "myFT Articles consumed per user", result: myFtArticles[i]["value"] / myFt[i]["value"] }
 					]
 			};
 
 			if (i === follow.length-1) { // chart the data
-				myFTChart
-					.parseRawData({ result: myFTUsageData })
+				myFtChart
+					.parseRawData({ result: myFtUsageData })
 					.render();
 
 				viewsChart

--- a/client/queries/myft/usage.js
+++ b/client/queries/myft/usage.js
@@ -33,6 +33,9 @@ function getFunnelGraph(el) {
 
 function usageForPeriod(startDate, endDate, name) {
 
+	const section = document.querySelector(`.section--${name}`);
+	const funnelGraph = getFunnelGraph(section.querySelector('.funnel'));
+
 	const nextUserCountQuery = new KeenQuery('dwell')
 		.count('user.uuid')
 		.absTime(startDate, endDate)
@@ -46,7 +49,7 @@ function usageForPeriod(startDate, endDate, name) {
 		.compare()
 		.print('json');
 
-	const myFtDailyEmailVisitorsQuery = new KeenQuery('email')
+	const myFtDailyEmailOpenersQuery = new KeenQuery('email')
 		.select('user.uuid')
 		.filter('event=open')
 		.filter('meta.emailType=daily')
@@ -54,21 +57,18 @@ function usageForPeriod(startDate, endDate, name) {
 		.compare()
 		.print('json');
 
-	Promise.all([nextUserCountQuery, myFtPageVisitorsQuery, myFtDailyEmailVisitorsQuery])
+	Promise.all([nextUserCountQuery, myFtPageVisitorsQuery, myFtDailyEmailOpenersQuery])
 		.then(results => {
 			const nextUserCount = results[0];
 			const myFtPageVisitors = results[1];
-			const myFtDailyEmailVisitors = results[2];
+			const myFtDailyEmailOpeners = results[2];
 
 			const myFtUserCount = {
-				curr: union(myFtPageVisitors.curr.result, myFtDailyEmailVisitors.curr.result).length,
-				prev: union(myFtPageVisitors.prev.result, myFtDailyEmailVisitors.prev.result).length
+				curr: union(myFtPageVisitors.curr.result, myFtDailyEmailOpeners.curr.result).length,
+				prev: union(myFtPageVisitors.prev.result, myFtDailyEmailOpeners.prev.result).length
 			};
 
-			var section = document.querySelector(`.section--${name}`);
-			var funnelGraph = getFunnelGraph(section.querySelector('.funnel'));
-
-			var combined = [
+			const combined = [
 				['Visited Next', nextUserCount.curr, nextUserCount.prev],
 				['Is a myFT user', myFtUserCount.curr, myFtUserCount.prev]
 			];

--- a/views/layouts/beacon.html
+++ b/views/layouts/beacon.html
@@ -73,6 +73,8 @@
 			window.cutsTheMustard = true;
 			window.keen_project = '{{keen_project}}';
 			window.keen_read_key = '{{keen_read_key}}';
+			window.KEEN_PROJECT_ID = '{{keen_project}}';
+			window.KEEN_READ_KEY = '{{keen_read_key}}';
 			window.page_name = '{{page_name}}';
 			window.article_id = '{{article_id}}';
 			window.original_url = '{{original_url}}';

--- a/views/myft-usage.html
+++ b/views/myft-usage.html
@@ -11,9 +11,9 @@
 
 <aside>
 	<h5>Definitions</h5>
-	<ul>A <strong>Next user </strong> here is defined as a user with a UUID (i.e. subscribers/registered users that we can recognize)</ul>
+	<ul>A <strong>Next user </strong> here is defined as a user with a UUID (i.e. subscribers/registered users that we can recognize).</ul>
 	<ul>A <strong>Follow user </strong> here is defined as a Next user who, at any point during the period specified, was following at least one topic.</ul>
-	<ul>A <strong>MyFT user </strong> is classified as anybody who read an article from a myFT source (e.g. email, news feed, tray etc) during the specified period</ul>
+	<ul>A <strong>MyFT user </strong> is classified as anybody who interacted with an article from a myFT source (e.g. email, news feed, tray etc) during the specified period.</ul>
 </aside>
 
 <section class="section--this-week">


### PR DESCRIPTION
Expand the definition of a *my*FT user to include users who open myft daily emails (based on the logic that users scanning headlines are benefitting from *my*FT).

First use of [n-keen-query](https://github.com/Financial-Times/n-keen-query) - nice!