### PR TITLE
Add: Functionality to select timeframe dates (front page vfu graph)

### DIFF
--- a/client/queries/front-page/volume-frequency-users.js
+++ b/client/queries/front-page/volume-frequency-users.js
@@ -48,22 +48,18 @@ const createTimestamp = daysAgoNum => {
 	return getPrecedingSunday(timestamp);
 }
 
-const convertToTimestamp = n => { return moment.unix(moment().startOf('day').unix()-(n * 86400)).toDate(); }
+const convertToTimestamp = n => moment.unix(moment().startOf('day').unix()-(n * 86400)).toDate();
 
 const getPrecedingSunday = timestamp => {
 	const diff = timestamp.getDate() - timestamp.getDay();
 	return new Date(timestamp.setDate(diff));
 }
 
-const getStartDate = timeframe => {
-	return createTimestamp(parseInt(timeframe) * 7);
-}
+const getStartDate = timeframe => createTimestamp(parseInt(timeframe) * 7);
 
-const getEndDate = timeframe => {
-	return createTimestamp((parseInt(timeframe) - 4) * 7);
-}
+const getEndDate = timeframe => createTimestamp((parseInt(timeframe) - 4) * 7);
 
-const generateAverageViews = (type, queryOpts = {}) => {
+const generateAverageViews = () => {
 	document.querySelector(`input[name="deviceType"][value="${queryParams.deviceType}"`)
 		.setAttribute('checked', 'checked');
 
@@ -73,40 +69,27 @@ const generateAverageViews = (type, queryOpts = {}) => {
 	document.querySelector(`input[name="timeframe"][value="${queryParams.timeframe}"`)
 		.setAttribute('checked', 'checked');
 
+	const queryOpts = {
+		eventCollection: 'dwell',
+		groupBy: ['user.uuid'],
+		timeframe: {
+			start: getStartDate(queryParams.timeframe),
+			end: getEndDate(queryParams.timeframe)
+		},
+		interval: 'weekly',
+		timezone: 'UTC'	
+	}
+
 	let pageViewsQueries = [
 		new Keen.Query('count', Object.assign({
-			eventCollection: 'dwell',
 			filters: getFilters('article'),
-			groupBy: ['user.uuid'],
-			timeframe: {
-				start: getStartDate(queryParams.timeframe),
-				end: getEndDate(queryParams.timeframe)
-			},
-			interval: 'weekly',
-			timezone: 'UTC'
 		}, queryOpts)),
 		new Keen.Query('count', Object.assign({
-			eventCollection: 'dwell',
 			filters: getFilters('frontpage'),
-			groupBy: ['user.uuid'],
-			timeframe: {
-				start: getStartDate(queryParams.timeframe),
-				end: getEndDate(queryParams.timeframe)
-			},
-			interval: 'weekly',
-			timezone: 'UTC'
 		}, queryOpts)),
 		new Keen.Query('count_unique', Object.assign({
 			targetProperty: 'ingest.device.spoor_session',
-			eventCollection: 'dwell',
 			filters: getFilters(),
-			groupBy: ['user.uuid'],
-			timeframe: {
-				start: getStartDate(queryParams.timeframe),
-				end: getEndDate(queryParams.timeframe)
-			},
-			interval: 'weekly',
-			timezone: 'UTC'
 		}, queryOpts))
 	];
 
@@ -142,16 +125,17 @@ const generateAverageViews = (type, queryOpts = {}) => {
 
 			const atLeastNUsers = (n) => {
 				const filteredVolume = volumeForWeek.filter(vol => vol.result >= n);
-				return (filteredVolume.length / frontPageUsersForWeekNum) * 100
+				const result = ((filteredVolume.length / frontPageUsersForWeekNum) * 100);
+				return parseFloat(result.toFixed(2))
 			};
 
-			const meanVolume = volumeForWeek.reduce(function(prev, current) {
+			const meanVolume = parseFloat((volumeForWeek.reduce(function(prev, current) {
 				return prev + current.result;
-			}, 0) / frontPageUsersForWeekNum;
+			}, 0) / frontPageUsersForWeekNum).toFixed(2));
 
-			const meanFrequency = visitsForWeek.reduce(function(prev, current) {
+			const meanFrequency = parseFloat((visitsForWeek.reduce(function(prev, current) {
 				return prev + current.result;
-			}, 0) / frontPageUsersForWeekNum;
+			}, 0) / frontPageUsersForWeekNum).toFixed(2));
 
 			return {
 				'timeframe': week.timeframe,

--- a/views/front-page-volume-frequency-users.html
+++ b/views/front-page-volume-frequency-users.html
@@ -34,15 +34,19 @@
             </div>
 
             <div>
-                <p class="performance-form__label--inline">Timeframe (weeks):</p>
-                <input type="radio" name="timeframe" value="this_2_weeks" class="o-forms-radio" id="timeframe-2" />
-                <label class="o-forms-label" for="timeframe-2">2</label>
-                <input type="radio" name="timeframe" value="this_4_weeks" class="o-forms-radio" id="timeframe-4" />
-                <label class="o-forms-label" for="timeframe-4">4</label>
-                <input type="radio" name="timeframe" value="this_6_weeks" class="o-forms-radio" id="timeframe-6" />
-                <label class="o-forms-label" for="timeframe-6">6</label>
-                <input type="radio" name="timeframe" value="this_8_weeks" class="o-forms-radio" id="timeframe-8" />
-                <label class="o-forms-label" for="timeframe-8">8</label>
+                <p class="performance-form__label--inline">Timeframe (weeks ago from now):</p>
+                <input type="radio" name="timeframe" value="4" class="o-forms-radio" id="timeframe-00-04" />
+                <label class="o-forms-label" for="timeframe-00-04">0-4</label>
+                <input type="radio" name="timeframe" value="8" class="o-forms-radio" id="timeframe-04-08" />
+                <label class="o-forms-label" for="timeframe-04-08">4-8</label>
+                <input type="radio" name="timeframe" value="12" class="o-forms-radio" id="timeframe-08-12" />
+                <label class="o-forms-label" for="timeframe-08-12">8-12</label>
+                <input type="radio" name="timeframe" value="16" class="o-forms-radio" id="timeframe-12-16" />
+                <label class="o-forms-label" for="timeframe-12-16">12-16</label>
+                <input type="radio" name="timeframe" value="20" class="o-forms-radio" id="timeframe-16-20" />
+                <label class="o-forms-label" for="timeframe-16-20">16-20</label>
+                <input type="radio" name="timeframe" value="24" class="o-forms-radio" id="timeframe-20-24" />
+                <label class="o-forms-label" for="timeframe-20-24">20-24</label>
             </div>
         </div>
         <input class="o-buttons" type="submit" value="Update Graph">


### PR DESCRIPTION
cc @ironsidevsquincy @adgad 

Functionality added to select a given four-week period, measured by the most recently completed week (ending Sunday midnight), so same as `previous_n_weeks`.

Currently missing the line between time periods; see below: 4-8 weeks (i) and 0-4 weeks (ii); should there be an overlap of dates so the graphs 'join up'?

(i)
![4-8](https://cloud.githubusercontent.com/assets/10484515/12583498/03dd01b4-c43b-11e5-8c25-6b2d958934b8.png)

(ii)
![0-4](https://cloud.githubusercontent.com/assets/10484515/12583502/0ea310b6-c43b-11e5-82c0-ad06a8a1e393.png)